### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 AbletonMCP connects Ableton Live to Claude AI through the Model Context Protocol (MCP), allowing Claude to directly interact with and control Ableton Live. This integration enables prompt-assisted music production, track creation, and Live session manipulation.
 
+<a href="https://glama.ai/mcp/servers/@sharray2918/ableton-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sharray2918/ableton-mcp/badge" alt="AbletonMCP MCP server" />
+</a>
+
 ### Join the Community
 
 Give feedback, get inspired, and build on top of the MCP: [Discord](https://discord.gg/3ZrMyGKnaU). Made by [Siddharth](https://x.com/sidahuj)


### PR DESCRIPTION
This PR adds a badge for the [AbletonMCP](https://glama.ai/mcp/servers/@sharray2918/ableton-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sharray2918/ableton-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sharray2918/ableton-mcp/badge" alt="AbletonMCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.